### PR TITLE
Update outdated dead link of MATE Wiki

### DIFF
--- a/data/jekyll-src/_data/home-navigation.yml
+++ b/data/jekyll-src/_data/home-navigation.yml
@@ -39,7 +39,7 @@
     - name: {{homeTrans.matehelp}}
       type: primary
       icon: life-ring
-      onclick: bridge.openURL('https://wiki.mate-desktop.org/docs')
+      onclick: bridge.openURL('https://wiki.mate-desktop.org/#!index.md')
       data-de: mate
     - name: {{homeTrans.enlightenmenthelp}}
       type: primary


### PR DESCRIPTION
Old link directs to a 404.
