### PR TITLE
panellayouter: use QTemporaryFile for applyLayout() (bsc#1213708, CVE-2023-32184)

### DIFF
--- a/data/xfce-apply-layout.py
+++ b/data/xfce-apply-layout.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python3
+
+import argparse
+import gi
+import sys
+
+sys.path.append('/usr/share/xfce4-panel-profiles/xfce4-panel-profiles/')
+from gi.repository import Gio
+from panelconfig import PanelConfig
+
+parser = argparse.ArgumentParser(
+        description="Applies a new XFCE desktop layout")
+parser.add_argument("layout", help="Path to a XFCE panel layout bzip2 file in from <prefix>/share/xfce4-panel-profiles/layouts")
+
+args = parser.parse_args()
+
+session_bus = Gio.BusType.SESSION
+cancellable = None
+connection = Gio.bus_get_sync(session_bus, cancellable)
+
+proxy_property = 0
+interface_properties_array = None
+destination = 'org.xfce.Xfconf'
+path = '/org/xfce/Xfconf'
+interface = destination
+
+xfconf = Gio.DBusProxy.new_sync(
+    connection,
+    proxy_property,
+    interface_properties_array,
+    destination,
+    path,
+    interface,
+    cancellable)
+
+PanelConfig.from_file(args.layout).to_xfconf(xfconf)

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,9 @@ qresource_files = ['data/qrc/qml.qrc', 'data/qrc/css.qrc', 'data/qrc/fonts.qrc',
 processed_files = qt5.preprocess(moc_headers: ['src/include/enabler.h', 'src/include/launcher.h', 'src/include/sysinfo.h', 'src/include/panellayouter.h'],
                                  include_directories: inc,
                                  qresources: qresource_files)
+
+share_dir = join_paths(get_option('prefix'), get_option('datadir'), 'openSUSE-Welcome')
+
 subdir('src')
 
 install_data('data/org.opensuse.opensuse_welcome.desktop', install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'applications'))
@@ -13,6 +16,7 @@ install_data('data/org.opensuse.opensuse_welcome.desktop', install_dir: join_pat
 install_data('data/org.opensuse.opensuse_welcome.appdata.xml', install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'metainfo'))
 install_data('data/org.opensuse.opensuse_welcome.svg', install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'icons/hicolor/scalable/apps'))
 install_data('data/org.opensuse.opensuse_welcome-symbolic.svg', install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'icons/hicolor/symbolic/apps'))
+install_data('data/xfce-apply-layout.py', install_dir: share_dir)
 
 meson.add_install_script('data/cleanup.sh')
-meson.add_install_script('data/i18n.sh', join_paths(get_option('prefix'), get_option('datadir'), 'openSUSE-Welcome', 'i18n'))
+meson.add_install_script('data/i18n.sh', join_paths(share_dir, 'i18n'))

--- a/src/include/panellayouter.h
+++ b/src/include/panellayouter.h
@@ -14,13 +14,6 @@ public:
     Q_INVOKABLE void setFont(const QString &theme);
     Q_INVOKABLE void runCommand(const QString &cmd);
     Q_INVOKABLE void setLook(const QString &look);
-
-private:
-    QString m_script;
-
-signals:
-
-public slots:
 };
 
 #endif // PANELLAYOUTER_H

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,4 +5,5 @@ welcome = executable('opensuse-welcome',
                      processed_files, 
                      include_directories : inc,
                      dependencies: qt5_dep,
+                     cpp_args: '-DWELCOME_SHARE_DIR="@0@"'.format(share_dir),
                      install: true)


### PR DESCRIPTION
This fixes a security issue, details of which will only be made available once updates are in place in openSUSE. SUSE employees may contact me for knowing the details in advance, but it shouldn't be necessary to review this change.

Place the Python helper script into the file system and package it. Let the script accept the path to a layout tarball as parameter. Write the application resource into a QTemporaryFile to make it accessible to the helper script.