### PR TITLE
Do not show in GNOME desktop

### DIFF
--- a/data/org.opensuse.opensuse_welcome.desktop
+++ b/data/org.opensuse.opensuse_welcome.desktop
@@ -27,3 +27,4 @@ GenericName[pl]=Program do powitania w openSUSE.
 Name[zh_CN]=欢迎
 Comment[zh_CN]=openSUSE 欢迎程序。
 GenericName[zh_CN]=欢迎程序
+NotShowIn=GNOME;


### PR DESCRIPTION
In order to use GNOME Tour [1] as a welcome app for openSUSE we need to disable this one to be shown in GNOME desktop.

This is part of the Hack Week project [2] to revisit the welcome application.

[1] https://github.com/openSUSE/gnome-tour
[2] https://hackweek.opensuse.org/projects/opensuse-welcome