### PR TITLE
Drop checkbox to enable autostart

### DIFF
--- a/data/qrc/main.qml
+++ b/data/qrc/main.qml
@@ -36,7 +36,6 @@ Window {
         bridgeObject.os = systemInfo.getOS();
         bridgeObject.de = launcher.currentDE();
         bridgeObject.live = enabler.isLive();
-        enabler.disableAutostart();
         console.log(bridgeObject.live);
     }
 

--- a/data/qrc/main.qml
+++ b/data/qrc/main.qml
@@ -35,8 +35,8 @@ Window {
         bridgeObject.arch = systemInfo.getArch();
         bridgeObject.os = systemInfo.getOS();
         bridgeObject.de = launcher.currentDE();
-        bridgeObject.enabled = enabler.autostartEnabled();
         bridgeObject.live = enabler.isLive();
+        enabler.disableAutostart();
         console.log(bridgeObject.live);
     }
 
@@ -105,7 +105,6 @@ Window {
         property string arch: ""
         property string os: ""
         property string de: ""
-        property bool enabled: true
         property bool live: false
         property bool ready: false
         property bool pastFirstPage: false

--- a/data/qrc/web/home.html
+++ b/data/qrc/web/home.html
@@ -161,10 +161,6 @@
                 </div>
             </div>
             <div class="d-flex">
-                <checkbox id="autostart" class="btn btn-sm btn-link text-white" ng-checked="bridge.enabled"
-                    ng-model="autostart" onclick="updateAutoStart()">
-                    {{homeTrans.autostart}}
-                </checkbox>
                 <button id="close" class="btn btn-sm btn-warning font-weight-bold de-footer" data-de="xfce" onclick="delayedClick('aqrc:///web/xfce.html')" lang="en">
                     <i class="fa fa-arrow-right"></i> {{homeTrans.customize}}
                 </button>


### PR DESCRIPTION
* The idea is to move away autostart feature to opensuse-welcome-launcher which then takes over executing plasma-welcome, gnome-tour, openSUSE-welcome. See previous announcement at [factory@](https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/RSGRBJYDIX77G3ZEOEPSKK4OTMTCHJIM/) 

* call disableAutostart() on complete just to be sure

<img width="1613" height="1241" alt="image" src="https://github.com/user-attachments/assets/084ce5b0-06af-4f17-9323-b847982a33d3" />
